### PR TITLE
feat: integrate Spotify API instead of YouTube for music search and p…

### DIFF
--- a/app/Music/page.jsx
+++ b/app/Music/page.jsx
@@ -1,125 +1,161 @@
 "use client";
 import { useState } from "react";
-import { FaPaperPlane } from "react-icons/fa";
+import { FaPaperPlane, FaSpotify } from "react-icons/fa";
 import axios from "axios";
 
-const API_KEY = process.env.NEXT_PUBLIC_YOUTUBE_API_KEY; // ✅ Corrected
-const BASE_URL = "https://www.googleapis.com/youtube/v3";
-
 const ChatMusicRecommender = () => {
-    const [messages, setMessages] = useState([
-        { text: "Hey there! How are you feeling today? 😊", isBot: true },
-    ]);
-    const [userInput, setUserInput] = useState("");
-    const [loading, setLoading] = useState(false);
+  const [messages, setMessages] = useState([
+    { text: "Hey there! How are you feeling today? 😊", isBot: true },
+  ]);
+  const [userInput, setUserInput] = useState("");
+  const [loading, setLoading] = useState(false);
 
-    const handleUserMessage = async () => {
-        if (!userInput.trim()) return;
+  const handleUserMessage = async () => {
+    if (!userInput.trim()) return;
 
-        const newMessages = [...messages, { text: userInput, isBot: false }];
-        setMessages(newMessages);
-        setLoading(true);
-        await suggestMusic(userInput);
-        setUserInput("");
-    };
+    const newMessages = [...messages, { text: userInput, isBot: false }];
+    setMessages(newMessages);
+    setLoading(true);
+    await suggestMusic(userInput);
+    setUserInput("");
+  };
 
-    const suggestMusic = async (userMessage) => {
-        try {
-            const response = await axios.get(`${BASE_URL}/search`, {
-                params: {
-                    part: "snippet",
-                    q: `${userMessage} music`,
-                    type: "video",
-                    videoCategoryId: 10, // Music category
-                    key: API_KEY,
-                    maxResults: 3, // Show 3 songs
-                },
-            });
+  const suggestMusic = async (userMessage) => {
+    try {
+      const res = await axios.get(`/api/music/spotify-search`, {
+        params: { q: userMessage },
+      });
 
-            const videos = response.data.items;
+      const { tracks } = res.data;
+      const items = tracks?.items || [];
 
-            if (!videos || videos.length === 0) {
-                setMessages((prevMessages) => [
-                    ...prevMessages,
-                    { text: "Sorry, I couldn't find any music for this mood. Try another one!", isBot: true },
-                ]);
-                return;
-            }
+      if (items.length === 0) {
+        setMessages((prev) => [
+          ...prev,
+          { text: "Sorry, no Spotify tracks found. Try again!", isBot: true },
+        ]);
+        return;
+      }
 
-            const botMessage = `I've found some ${userMessage} tracks for you! 🎶`;
-            const songMessages = videos.map((video) => ({
-                text: (
-                    <iframe
-                        key={video.id.videoId}
-                        width="280"
-                        height="158"
-                        src={`https://www.youtube.com/embed/${video.id.videoId}`}
-                        frameBorder="0"
-                        allowFullScreen
-                    ></iframe>
-                ),
-                isBot: true,
-            }));
+      const botMessage = `Here are some ${userMessage} vibes from Spotify 🎧`;
 
-            setMessages((prevMessages) => [...prevMessages, { text: botMessage, isBot: true }, ...songMessages]);
-        } catch (error) {
-            console.error("Error fetching music recommendations:", error);
-            setMessages((prevMessages) => [
-                ...prevMessages,
-                { text: "Sorry, there was an error fetching the music. Please try again later.", isBot: true },
-            ]);
-        } finally {
-            setLoading(false);
-        }
-    };
-
-    return (
-        <div className="flex flex-col h-screen relative">
-            {/* Background Image */}
+      const trackMessages = items.map((track) => ({
+        text: (
+          <div
+            key={track.id}
+            className="w-64 rounded-2xl shadow-lg bg-white/90 p-3 flex flex-col space-y-2 hover:shadow-2xl transition"
+          >
+            {/* Album Cover */}
             <img
-                src="/music.png"
-                alt="Background"
-                className="absolute inset-0 w-full h-full object-cover opacity-90 z-0"
+              src={track.album.images[0]?.url}
+              alt={track.name}
+              className="w-full h-40 object-cover rounded-xl"
             />
 
-            <div className="relative z-10 flex items-center justify-center rounded-3xl bg-gradient-to-r from-cyan-400 via-cyan-500 to-cyan-600 p-4 shadow-lg">
-                <h1 className="text-lg font-semibold text-white">ParthSangeet 🎶</h1>
+            {/* Track Info */}
+            <div>
+              <p className="font-semibold text-gray-900 truncate">{track.name}</p>
+              <p className="text-sm text-gray-600">
+                {track.artists.map((a) => a.name).join(", ")}
+              </p>
             </div>
 
-            <div className="relative z-10 flex-1 mt-4 overflow-auto mb-4 px-4">
-                {messages.map((message, index) => (
-                    <div key={index} className={`flex ${message.isBot ? "justify-start" : "justify-end"} mb-3`}>
-                        <div
-                            className={`px-4 py-2 rounded-lg max-w-xs ${
-                                message.isBot
-                                    ? "bg-gradient-to-br from-green-400 to-blue-600 text-gray-800"
-                                    : "bg-gradient-to-br from-blue-600 to-green-400 text-white"
-                            }`}
-                        >
-                            {message.text}
-                        </div>
-                    </div>
-                ))}
-            </div>
+            {/* Preview */}
+            {track.preview_url ? (
+              <audio
+                controls
+                className="w-full mt-1 rounded-lg bg-gray-100"
+              >
+                <source src={track.preview_url} type="audio/mpeg" />
+                Your browser does not support audio
+              </audio>
+            ) : (
+              <p className="text-xs text-gray-500">Preview not available</p>
+            )}
 
-            <div className="relative bg-gradient-to-r from-teal-400 via-teal-500 to-teal-600 rounded-3xl z-10 flex items-center space-x-2 p-3 mx-3 mb-4">
-                <input
-                    type="text"
-                    className="w-full p-2 border rounded-3xl"
-                    placeholder="Type your mood..."
-                    value={userInput}
-                    onChange={(e) => setUserInput(e.target.value)}
-                />
-                <button
-                    onClick={handleUserMessage}
-                    className="ml-2 p-3 bg-[#1E7F5C] hover:bg-[#175344] text-white rounded-full shadow-lg hover:shadow-xl transition duration-200"
-                    disabled={loading}
-                >
-                    {loading ? "..." : <FaPaperPlane size={20} />}
-                </button>
+            {/* Spotify Button */}
+            <a
+              href={track.external_urls.spotify}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center justify-center space-x-2 bg-green-500 hover:bg-green-600 text-white px-3 py-2 rounded-xl mt-2 transition"
+            >
+              <FaSpotify /> <span>Open in Spotify</span>
+            </a>
+          </div>
+        ),
+        isBot: true,
+      }));
+
+      setMessages((prev) => [
+        ...prev,
+        { text: botMessage, isBot: true },
+        ...trackMessages,
+      ]);
+    } catch (error) {
+      console.error(error);
+      setMessages((prev) => [
+        ...prev,
+        { text: "Error fetching Spotify music. Try later!", isBot: true },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-screen relative">
+      {/* Background Image */}
+      <img
+        src="/music.png"
+        alt="Background"
+        className="absolute inset-0 w-full h-full object-cover opacity-90 z-0"
+      />
+
+      {/* Header */}
+      <div className="relative z-10 flex items-center justify-center rounded-3xl bg-gradient-to-r from-cyan-400 via-cyan-500 to-cyan-600 p-4 shadow-lg">
+        <h1 className="text-lg font-semibold text-white">ParthSangeet 🎶</h1>
+      </div>
+
+      {/* Chat Messages */}
+      <div className="relative z-10 flex-1 mt-4 overflow-auto mb-4 px-4 space-y-3">
+        {messages.map((message, index) => (
+          <div
+            key={index}
+            className={`flex ${message.isBot ? "justify-start" : "justify-end"}`}
+          >
+            <div
+              className={`px-4 py-2 rounded-2xl max-w-sm ${
+                message.isBot
+                  ? "bg-white/80 text-gray-800 shadow"
+                  : "bg-gradient-to-br from-blue-600 to-green-400 text-white shadow-lg"
+              }`}
+            >
+              {message.text}
             </div>
-        </div>
-    );
+          </div>
+        ))}
+      </div>
+
+      {/* Input */}
+      <div className="relative bg-gradient-to-r from-teal-400 via-teal-500 to-teal-600 rounded-3xl z-10 flex items-center space-x-2 p-3 mx-3 mb-4 shadow-xl">
+        <input
+          type="text"
+          className="w-full p-2 border rounded-3xl focus:outline-none focus:ring-2 focus:ring-green-400"
+          placeholder="Type your mood..."
+          value={userInput}
+          onChange={(e) => setUserInput(e.target.value)}
+        />
+        <button
+          onClick={handleUserMessage}
+          className="ml-2 p-3 bg-[#1E7F5C] hover:bg-[#175344] text-white rounded-full shadow-lg hover:shadow-xl transition duration-200"
+          disabled={loading}
+        >
+          {loading ? "..." : <FaPaperPlane size={20} />}
+        </button>
+      </div>
+    </div>
+  );
 };
 
 export default ChatMusicRecommender;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "chatbot",
       "version": "0.1.0",
-      "hasInstallScript": true,
       "dependencies": {
         "@hookform/resolvers": "^5.2.1",
         "animate.css": "^4.1.1",

--- a/pages/api/music/spotify-search.js
+++ b/pages/api/music/spotify-search.js
@@ -1,0 +1,18 @@
+export default async function handler(req, res) {
+  const { q, type = "track" } = req.query;
+
+//  get token
+  const tokenRes = await fetch(`${NEXT_PUBLIC_BASE_URL}/api/music/spotify-token`);
+  const { access_token } = await tokenRes.json();
+
+  // Search Spotify
+  const searchRes = await fetch(
+    `https://api.spotify.com/v1/search?q=${q}&type=${type}&limit=5`,
+    {
+      headers: { Authorization: `Bearer ${access_token}` },
+    }
+  );
+
+  const data = await searchRes.json();
+  res.status(200).json(data);
+}

--- a/pages/api/music/spotify-token.js
+++ b/pages/api/music/spotify-token.js
@@ -1,0 +1,20 @@
+export default async function handler(req, res) {
+  const authOptions = {
+    method: "POST",
+    headers: {
+      "Authorization": "Basic " + Buffer.from(
+        process.env.SPOTIFY_CLIENT_ID + ":" + process.env.SPOTIFY_CLIENT_SECRET
+      ).toString("base64"),
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: new URLSearchParams({ grant_type: "client_credentials" }).toString(),
+  };
+
+  try {
+    const response = await fetch("https://accounts.spotify.com/api/token", authOptions);
+    const data = await response.json();
+    res.status(200).json(data);  
+  } catch (err) {
+    res.status(500).json({ error: "Failed to get token" });
+  }
+}


### PR DESCRIPTION
This pull request addresses issue #26 by integrating the Spotify Web API into the Parth-Mind application. The aim is to deliver a more engaging, music-focused experience by enabling users to search, preview, and access songs directly from Spotify.

**🔑 Key Updates**
Backend (API Routes):

- Implemented _/api/music/spotify-token.js_ to securely handle the Spotify Client Credentials flow and provide access tokens to the frontend.
- Implemented _/api/music/spotify-search.js_ to perform authenticated search queries against the Spotify API and return track results.

**Frontend Integration:**
Updated the _ChatMusicRecommender_ component to interact with the new backend routes.
The suggestMusic function now uses the Spotify search API to provide personalized music recommendations.

**Enhanced the UI to display:**

- 🎵 Track title and artist(s)
- 🎨 Album artwork
- 🎧 30-second preview with playback controls (or a fallback message if unavailable)
- 🔗 “Play on Spotify” button linking to the full track.
 
**Set your env** 
`SPOTIFY_CLIENT_ID=your_client_id
SPOTIFY_CLIENT_SECRET=your_client_secret`

**Demo**
https://github.com/user-attachments/assets/36b51a24-0eeb-41d0-ac0e-735030568c77

